### PR TITLE
Correct instructions for Colombo tests

### DIFF
--- a/tests/2_functional-tests.js
+++ b/tests/2_functional-tests.js
@@ -241,9 +241,9 @@ suite('Functional Tests', function() {
 
             // assert that status is OK 200
 
-            // assert that the text inside the element 'span#name' is 'Marco'
+            // assert that the text inside the element 'span#name' is 'Cristoforo'
 
-            // assert that the text inside the element 'span#surname' is 'Polo'
+            // assert that the text inside the element 'span#surname' is 'Colombo'
 
             // assert that the element(s) 'span#dates' exist and their count is 1
             


### PR DESCRIPTION
The instructions in the comments were incorrect for the test when submitting {surname: 'Colombo'} as we would not expect Marco Polo to be returned. The instructions have been updated to the correct expected values of Cristoforo for name and Colombo for surname