### PR TITLE
fix: Change Test Name

### DIFF
--- a/tests/2_functional-tests.js
+++ b/tests/2_functional-tests.js
@@ -53,7 +53,7 @@ suite("Functional Tests", function () {
 
 const Browser = require("zombie");
 
-suite("Functional Testing with Zombie.js", function () {
+suite("Functional Tests with Zombie.js", function () {
 
   suite('"Famous Italian Explorers" form', function () {
     // #5

--- a/tests/2_functional-tests.js
+++ b/tests/2_functional-tests.js
@@ -53,7 +53,7 @@ suite("Functional Tests", function () {
 
 const Browser = require("zombie");
 
-suite("e2e Testing with Zombie.js", function () {
+suite("Functional Testing with Zombie.js", function () {
 
   suite('"Famous Italian Explorers" form', function () {
     // #5


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

The `_api/get-tests` endpoint doesn't properly filter these as functional tests because they don't match "Functional Tests". Tweaking this wording will allow our URL queries to function as intended.