### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
 		"zombie": "^4.2.1",
 		"cors": "^2.8.1"
 	},
-	"engines": {
-		"node": "4.4.5"
-	},
 	"repository": {
 		"type": "git",
 		"url": "https://hyperdev.com/#!/project/welcome-project"


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365