### PR TITLE
fix: Change test #10 in comparisons suite

### DIFF
--- a/tests/1_unit-tests.js
+++ b/tests/1_unit-tests.js
@@ -75,8 +75,8 @@ suite('Unit Tests', function () {
     });
     // #10
     test('#approximately', function () {
-      assert.approximately(weirdNumbers(0.5), 1, 0);
-      assert.approximately(weirdNumbers(0.2), 1, 0);
+      assert.fail(weirdNumbers(0.5), 1, 0);
+      assert.fail(weirdNumbers(0.2), 1, 0);
     });
   });
 


### PR DESCRIPTION
The test instructions mention

> Within `tests/1_unit-tests.js` under the test labelled `#10` in the `Comparisons suite`, change each `assert` to `assert.approximately`

but in the test, both assertions are already replaced by `assert.approximately`. I changed them to `assert.fail` like all the other tests so that they stay consistent with instructions. I hope it's good now.
