### PR TITLE
fix: use default port if not defined in .env

### DIFF
--- a/server.js
+++ b/server.js
@@ -82,8 +82,9 @@ app.get('/_api/get-tests', cors(), function (req, res, next) {
   });
 
 
-app.listen(3000, function () {
-  console.log("Listening on port " + 3000);
+const port = process.env.PORT || 3000;
+app.listen(port, function () {
+  console.log("Listening on port " + port);
   console.log('Running Tests...');
   setTimeout(function () {
     try {


### PR DESCRIPTION
Checklist:
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

This change makes the server run on process.env.PORT if that environment variable exists. Purpose of this is that in the current version the deployment will fail on Heroku and some other services that require the port to be determined by the environment. 

It is already implemented in a similar way in many other FCC projects such as:
https://github.com/freeCodeCamp/boilerplate-express/blob/gomix/server.js
https://github.com/freeCodeCamp/boilerplate-mongomongoose/blob/gomix/server.js
