### PR TITLE
fix: add `.keepOpen()` method to boilerplate tests

### DIFF
--- a/tests/2_functional-tests.js
+++ b/tests/2_functional-tests.js
@@ -13,6 +13,7 @@ suite('Functional Tests', function () {
     test('Test GET /hello with no name', function (done) {
       chai
         .request(server)
+        .keepOpen()
         .get('/hello')
         .end(function (err, res) {
           assert.fail(res.status, 200);
@@ -24,6 +25,7 @@ suite('Functional Tests', function () {
     test('Test GET /hello with your name', function (done) {
       chai
         .request(server)
+        .keepOpen()
         .get('/hello?name=xy_z')
         .end(function (err, res) {
           assert.fail(res.status, 200);
@@ -35,6 +37,7 @@ suite('Functional Tests', function () {
     test('Send {surname: "Colombo"}', function (done) {
       chai
         .request(server)
+        .keepOpen()
         .put('/travellers')
 
         .end(function (err, res) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/49878

<!-- Feel free to add any additional description of changes below this line -->
This adds the `.keepOpen()` method to the boilerplate to prevent `chai-http` from automatically stopping the server and causing all Learn tests to fail.

Here's a link to the completed project on Replit with these changes for testing: https://replit.com/@scissorsneedfoo/boilerplate-mochachai-complete#tests/2_functional-tests.js

Note: This shouldn't be merged until the changes in https://github.com/freeCodeCamp/freeCodeCamp/pull/49878 are live.